### PR TITLE
feat: add search endpoint

### DIFF
--- a/app/rest/api.py
+++ b/app/rest/api.py
@@ -1,5 +1,8 @@
-from ninja import Router
+from ninja import Router, Query, Schema
+from typing import Optional
+from .models import Rcr
 from .views import ClientConfigView
+
 
 router = Router()
 
@@ -8,3 +11,96 @@ router = Router()
 def get_client_config(request):
     view = ClientConfigView()
     return view.get(request).data
+
+
+class RcrSearchFilters(Schema):
+    language: Optional[str] = None
+    region: Optional[int] = None
+    department: Optional[int] = None
+    city: Optional[int] = None
+    rcr_type: Optional[str] = None
+    book_type: Optional[str] = None
+    publisher: Optional[str] = None
+    page: int = 1
+    per_page: int = 20
+
+
+@router.get("/rcr/search")
+def search_rcr(request, filters: RcrSearchFilters = Query(...)):
+    queryset = Rcr.objects.select_related(
+        "type", "city__department__region", "country_type"
+    ).prefetch_related(
+        "rcrbook_set__book__lang",
+        "rcrbook_set__book__type",
+        "rcrbook_set__book__editor",
+    )
+
+    if filters.region:
+        queryset = queryset.filter(city__department__region_id=filters.region)
+    if filters.department:
+        queryset = queryset.filter(city__department_id=filters.department)
+    if filters.city:
+        queryset = queryset.filter(city_id=filters.city)
+
+    if filters.rcr_type:
+        queryset = queryset.filter(type__label=filters.rcr_type)
+
+    if filters.language:
+        queryset = queryset.filter(rcrbook__book__lang__iso_code=filters.language)
+
+    if filters.book_type:
+        queryset = queryset.filter(rcrbook__book__type__label=filters.book_type)
+
+    if filters.publisher:
+        queryset = queryset.filter(
+            rcrbook__book__editor__title__icontains=filters.publisher
+        )
+
+    queryset = queryset.distinct()
+
+    total = queryset.count()
+    start = (filters.page - 1) * filters.per_page
+    end = start + filters.per_page
+    queryset = queryset[start:end]
+
+    return {
+        "pagination": {
+            "totalResults": total,
+            "currentPage": filters.page,
+            "itemsPerPage": filters.per_page,
+            "remainingItems": max(0, total - (filters.page * filters.per_page)),
+        },
+        "items": [
+            {
+                "rcr": rcr.rcr_number,
+                "name": rcr.title,
+                "translatedName": None,
+                "numberOfDocuments": rcr.rcrbook_set.count(),
+                "contact": {
+                    "website": rcr.website,
+                    "phone": rcr.phone,
+                    "email": rcr.email,
+                    "address": {
+                        "street": rcr.address,
+                        "postalCode": rcr.city.zipcode if rcr.city else None,
+                        "city": rcr.city.label if rcr.city else None,
+                        "country": "France",
+                    },
+                },
+                "location": {"longitude": rcr.longitude, "latitude": rcr.latitude},
+                "languages": {
+                    "count": None,  # TODO,
+                    "supported": None,  # TODO,
+                },
+                "metadata": {
+                    "author": None,  # TODO
+                    "publicationPlace": None,  # TODO
+                    "publisher": None,  # TODO
+                    "publicationDate": None,  # TODO
+                    "documentLanguage": None,  # TODO
+                    "tags": None,  # TODO,
+                },
+            }
+            for rcr in queryset
+        ],
+    }

--- a/app/rest/api.py
+++ b/app/rest/api.py
@@ -21,6 +21,7 @@ class RcrSearchFilters(Schema):
     rcr_type: Optional[str] = None
     book_type: Optional[str] = None
     publisher: Optional[str] = None
+    map_format: Optional[bool] = False
     page: int = 1
     per_page: int = 20
 
@@ -61,46 +62,66 @@ def search_rcr(request, filters: RcrSearchFilters = Query(...)):
     total = queryset.count()
     start = (filters.page - 1) * filters.per_page
     end = start + filters.per_page
-    queryset = queryset[start:end]
-
-    return {
-        "pagination": {
-            "totalResults": total,
-            "currentPage": filters.page,
-            "itemsPerPage": filters.per_page,
-            "remainingItems": max(0, total - (filters.page * filters.per_page)),
-        },
-        "items": [
-            {
-                "rcr": rcr.rcr_number,
-                "name": rcr.title,
-                "translatedName": None,
-                "numberOfDocuments": rcr.rcrbook_set.count(),
-                "contact": {
-                    "website": rcr.website,
-                    "phone": rcr.phone,
-                    "email": rcr.email,
-                    "address": {
-                        "street": rcr.address,
-                        "postalCode": rcr.city.zipcode if rcr.city else None,
-                        "city": rcr.city.label if rcr.city else None,
-                        "country": "France",
+    if not filters.map_format:
+        queryset = queryset[start:end]
+        return {
+            "pagination": {
+                "totalResults": total,
+                "currentPage": filters.page,
+                "itemsPerPage": filters.per_page,
+                "remainingItems": max(0, total - (filters.page * filters.per_page)),
+            },
+            "items": [
+                {
+                    "rcr": rcr.rcr_number,
+                    "name": rcr.title,
+                    "translatedName": None,
+                    "numberOfDocuments": rcr.rcrbook_set.count(),
+                    "contact": {
+                        "website": rcr.website,
+                        "phone": rcr.phone,
+                        "email": rcr.email,
+                        "address": {
+                            "street": rcr.address,
+                            "postalCode": rcr.city.zipcode if rcr.city else None,
+                            "city": rcr.city.label if rcr.city else None,
+                            "country": "France",
+                        },
                     },
-                },
-                "location": {"longitude": rcr.longitude, "latitude": rcr.latitude},
-                "languages": {
-                    "count": None,  # TODO,
-                    "supported": None,  # TODO,
-                },
-                "metadata": {
-                    "author": None,  # TODO
-                    "publicationPlace": None,  # TODO
-                    "publisher": None,  # TODO
-                    "publicationDate": None,  # TODO
-                    "documentLanguage": None,  # TODO
-                    "tags": None,  # TODO,
-                },
-            }
-            for rcr in queryset
-        ],
-    }
+                    "location": {"longitude": rcr.longitude, "latitude": rcr.latitude},
+                    "languages": {
+                        "count": None,  # TODO,
+                        "supported": None,  # TODO,
+                    },
+                    "metadata": {
+                        "author": None,  # TODO
+                        "publicationPlace": None,  # TODO
+                        "publisher": None,  # TODO
+                        "publicationDate": None,  # TODO
+                        "documentLanguage": None,  # TODO
+                        "tags": None,  # TODO,
+                    },
+                }
+                for rcr in queryset
+            ],
+        }
+    else:
+        return {
+            "items": [
+                {
+                    "rcr": rcr.rcr_number,
+                    "name": rcr.title,
+                    "numberOfDocuments": rcr.rcrbook_set.count(),
+                    "contact": {
+                        "address": {
+                            "street": rcr.address,
+                            "postalCode": rcr.city.zipcode if rcr.city else None,
+                            "city": rcr.city.label if rcr.city else None,
+                            "country": "France",
+                        }
+                    },
+                    "location": {"longitude": rcr.longitude, "latitude": rcr.latitude},
+                }
+                for rcr in queryset
+            ],
+        }

--- a/app/rest/urls.py
+++ b/app/rest/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 from .views import ClientConfigView
+from .api import router
 
 urlpatterns = [
     path("api/client-config", ClientConfigView.as_view(), name="client-config"),
+    path("api/", router.urls),
 ]


### PR DESCRIPTION
# 🔍 Ajout d'un endpoint de recherche RCR

## Description
Ajout d'un nouvel endpoint `/api/rcr/search` permettant de rechercher des RCR (Répertoire des Centres de Ressources) avec différents filtres.

## Fonctionnalités
- Endpoint de recherche avec pagination
- Filtres disponibles :
  - Langue (`language`)
  - Région (`region`)
  - Département (`department`) 
  - Ville (`city`)
  - Type de RCR (`rcr_type`)
  - Type de livre (`book_type`)
  - Éditeur (`publisher`)
- Pagination configurable (page et nombre d'éléments par page)
- Réponse formatée incluant :
  - Informations de pagination
  - Liste des RCR avec leurs détails (coordonnées, adresse, etc.)

## Modifications techniques
- Ajout du schéma `RcrSearchFilters` pour la validation des paramètres
- Utilisation de `select_related` et `prefetch_related` pour optimiser les requêtes
- Gestion des filtres optionnels
- Support de la pagination avec calcul du nombre d'éléments restants

## Tests à effectuer
- Vérifier le fonctionnement des différents filtres
- Tester la pagination
- Valider le format de la réponse
- Vérifier les performances avec un grand nombre de résultats