### PR TITLE
Feat/routes publisher city

### DIFF
--- a/app/rest/api.py
+++ b/app/rest/api.py
@@ -1,6 +1,6 @@
 from ninja import Router, Query, Schema
 from typing import Optional
-from .models import Book
+from .models import Book, Editor, City
 from .views import ClientConfigView
 from django.db.models import Q
 
@@ -156,3 +156,35 @@ def search_rcr(request, filters: RcrSearchFilters = Query(...)):
             ],
         }
     return response
+
+
+class EditorSearchFilters(Schema):
+    search: str
+
+
+@router.get("/editor/search")
+def search_editor(request, filters: EditorSearchFilters = Query(...)):
+    if len(filters.search) < 3:
+        return {"items": []}
+
+    queryset = Editor.objects.filter(title__icontains=filters.search).values(
+        "id", "title"
+    )[:10]
+
+    return {"items": list(queryset)}
+
+
+class CitySearchFilters(Schema):
+    search: str
+
+
+@router.get("/city/search")
+def search_city(request, filters: CitySearchFilters = Query(...)):
+    if len(filters.search) < 3:
+        return {"items": []}
+
+    queryset = City.objects.filter(label__icontains=filters.search).values(
+        "id", "label", "zipcode"
+    )[:10]
+
+    return {"items": list(queryset)}


### PR DESCRIPTION
# 🔍 Ajout des endpoints de recherche pour les éditeurs et les villes

## Description
Ajout de deux nouveaux endpoints pour faciliter la recherche d'éditeurs et de villes dans l'application.

### 🔄 Nouveaux endpoints
- `/editor/search` : Recherche d'éditeurs par titre
- `/city/search` : Recherche de villes par label

### ⚙️ Caractéristiques communes
- Recherche minimale de 3 caractères
- Limite de 10 résultats par requête
- Recherche insensible à la casse (icontains)
- Réponse optimisée avec `values()`

### 📝 Format des réponses
**Editor search :**
```json
{
    "items": [
        {"id": 1, "title": "Editeur exemple"}
    ]
}
```

**City search :**
```json
{
    "items": [
        {"id": 1, "label": "Paris", "zipcode": "75000"}
    ]
}
```