### PR TITLE
Feat/variabilize front

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -25,6 +25,11 @@ env:
   DJANGO_HTTP_PORT: ${{vars.DJANGO_HTTP_PORT}}
   DJANGO_HTTPS_PORT: ${{vars.DJANGO_HTTPS_PORT}}
   SECRET_KEY: ${{vars.SECRET_KEY}}
+  VITE_API_PROTOCOL: https
+  VITE_API_HOST: ${{vars.HOST}}
+  VITE_API_PATH: /api/rest
+  VITE_CACHE_TTL: 1000
+
 jobs:
   deploy_staging:
     environment: staging

--- a/app/cabestan/settings.py
+++ b/app/cabestan/settings.py
@@ -35,6 +35,12 @@ CSRF_TRUSTED_ORIGINS = [f"https://{i}" for i in ALLOWED_HOSTS] + [
     f"http://{i}" for i in ALLOWED_HOSTS
 ]
 
+CORS_ALLOWED_ORIGINS = (
+    [f"https://{i}" for i in ALLOWED_HOSTS]
+    + [f"http://{i}" for i in ALLOWED_HOSTS]
+    + ["http://servogne.com:5173", "http://localhost:5173"]
+)
+
 CABESTAN_ENV_LIST = ["PROD", "STAGING", "DEV"]
 CABESTAN_ENV = "PROD"
 
@@ -62,11 +68,13 @@ INSTALLED_APPS = [
     "constance",
     "constance.backends.database",
     "rest_framework",
+    "corsheaders",
 ] + [a + ".apps." + a.title() + "Config" for a in CABESTAN_APPS]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -63,3 +63,4 @@ tzdata==2025.1
 urllib3==2.3.0
 vine==5.1.0
 wcwidth==0.2.13
+django-cors-headers==4.7.0

--- a/app/rest/api.py
+++ b/app/rest/api.py
@@ -18,9 +18,9 @@ class RcrSearchFilters(Schema):
     search: Optional[str] = None
     search_type: Optional[str] = None
     language: Optional[str] = None
-    region: Optional[int] = None
-    department: Optional[int] = None
-    city: Optional[int] = None
+    region: Optional[str] = None
+    department: Optional[str] = None
+    city: Optional[str] = None
     rcr_type: Optional[str] = None
     book_type: Optional[str] = None
     publisher: Optional[str] = None
@@ -67,23 +67,46 @@ def search_rcr(request, filters: RcrSearchFilters = Query(...)):
         queryset = queryset.filter(search_query)
 
     if filters.region:
-        queryset = queryset.filter(rcr__city__department__region_id=filters.region)
+        region_query = Q()
+        for region_id in filters.region.split(","):
+            region_query |= Q(rcr__city__department__region_id=region_id.strip())
+        queryset = queryset.filter(region_query)
+
     if filters.department:
-        queryset = queryset.filter(rcr__city__department_id=filters.department)
+        department_query = Q()
+        for department_id in filters.department.split(","):
+            department_query |= Q(rcr__city__department_id=department_id.strip())
+        queryset = queryset.filter(department_query)
+
     if filters.city:
-        queryset = queryset.filter(rcr__city_id=filters.city)
+        city_query = Q()
+        for city_id in filters.city.split(","):
+            city_query |= Q(rcr__city_id=city_id.strip())
+        queryset = queryset.filter(city_query)
 
     if filters.rcr_type:
-        queryset = queryset.filter(rcr__type__label=filters.rcr_type)
+        rcr_query = Q()
+        for rcr_type in filters.rcr_type.split(","):
+            rcr_query |= Q(rcr__type__label=rcr_type.strip())
+        queryset = queryset.filter(rcr_query)
 
     if filters.language:
-        queryset = queryset.filter(lang__iso_code=filters.language)
+        lang_query = Q()
+        for lang in filters.language.split(","):
+            lang_query |= Q(lang__iso_code=lang.strip())
+        queryset = queryset.filter(lang_query)
 
     if filters.book_type:
-        queryset = queryset.filter(type__label=filters.book_type)
+        book_type_query = Q()
+        for b_type in filters.book_type.split(","):
+            book_type_query |= Q(type__label=b_type.strip())
+        queryset = queryset.filter(book_type_query)
 
     if filters.publisher:
-        queryset = queryset.filter(editor__title__icontains=filters.publisher)
+        publisher_query = Q()
+        for pub in filters.publisher.split(","):
+            publisher_query |= Q(editor__title__icontains=pub.strip())
+        queryset = queryset.filter(publisher_query)
 
     queryset = queryset.distinct("rcr__books_count", "rcr")
 

--- a/app/rest/serializers.py
+++ b/app/rest/serializers.py
@@ -44,25 +44,3 @@ class ConfigDepartmentSerializer(serializers.ModelSerializer):
 
     def get_slug(self, obj):
         return str(obj.id).zfill(2)  # Pour avoir "01" au lieu de "1"
-
-
-class ConfigCitySerializer(serializers.ModelSerializer):
-    slug = serializers.SerializerMethodField()
-
-    class Meta:
-        model = City
-        fields = ["slug"]
-
-    def get_slug(self, obj):
-        return obj.label.lower()
-
-
-class ConfigEditorSerializer(serializers.ModelSerializer):
-    slug = serializers.SerializerMethodField()
-
-    class Meta:
-        model = Editor
-        fields = ["slug"]
-
-    def get_slug(self, obj):
-        return obj.title.lower()

--- a/app/rest/views.py
+++ b/app/rest/views.py
@@ -1,13 +1,11 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from .models import Lang, RcrType, BookType, Department, City, Editor
+from .models import Lang, RcrType, BookType, Department
 from .serializers import (
     ConfigLangSerializer,
     ConfigRcrTypeSerializer,
     ConfigBookTypeSerializer,
     ConfigDepartmentSerializer,
-    ConfigCitySerializer,
-    ConfigEditorSerializer,
 )
 
 # Create your views here.
@@ -20,9 +18,6 @@ class ClientConfigView(APIView):
         establishment_types = RcrType.objects.all()
         document_types = BookType.objects.all()
         departments = Department.objects.all()
-        cities = City.objects.all()
-        publishers = Editor.objects.all()
-
         # Sérialiser les données
         data = {
             "languages": ConfigLangSerializer(languages, many=True).data,
@@ -31,8 +26,6 @@ class ClientConfigView(APIView):
             ],
             "documentTypes": ConfigBookTypeSerializer(document_types, many=True).data,
             "departments": ConfigDepartmentSerializer(departments, many=True).data,
-            "city": ConfigCitySerializer(cities, many=True).data,
-            "publisher": ConfigEditorSerializer(publishers, many=True).data,
         }
 
         return Response(data)

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,8 +7,9 @@ import LayoutBase from "./layouts/LayoutBase";
 const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
-			gcTime: 1000, // 1 second
+			gcTime: import.meta.env.VITE_CACHE_TTL?import.meta.env.VITE_CACHE_TTL:1000, // 1 second
 			// gcTime: 1000 * 60 * 60 * 24, // 24 hours
+			staleTime: import.meta.env.VITE_CACHE_TTL?import.meta.env.VITE_CACHE_TTL:1000, // 1 second
 		},
 	},
 });

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -1,6 +1,16 @@
 import { GlobalSuggestionType } from "@/models/Suggestions";
 
-const API_HOST = "http://localhost:8082";
+const API_HOST = import.meta.env.VITE_API_HOST ?? "localhost";
+const API_PROTOCOL = import.meta.env.VITE_API_PROTOCOL ?? "http";
+const API_PATH = import.meta.env.VITE_API_PATH ?? "/api/rest";
+
+const getApiUrl = (path: string) => `${API_PROTOCOL}://${API_HOST}${API_PATH}${path}`;
+
+const getApiHeaders = () => {
+	const headers = new Headers();
+	headers.set("Authorization", "Bearer a");
+	return headers;
+};
 
 type getClientConfigResponse = {
 	languages: { slug: string }[];
@@ -13,7 +23,7 @@ type getClientConfigResponse = {
 };
 
 export const getClientConfig = async (): Promise<getClientConfigResponse> => {
-	const response = await fetch(`${API_HOST}/api/client-config`);
+	const response = await fetch(`${getApiUrl("/client-config")}`,{headers:getApiHeaders()});
 	return response.json();
 };
 
@@ -26,7 +36,7 @@ type getGlobalSuggestionsResponse = {
 export const getGlobalSuggestions = async (value: string | undefined): Promise<getGlobalSuggestionsResponse[]> => {
 	if (!value) return [];
 
-	const response = await fetch(`${API_HOST}/api/rcr/suggestion?str=${value}`);
+	const response = await fetch(`${getApiUrl("/suggestion")}?str=${value}`,{headers:getApiHeaders()});
 	return response.json();
 };
 
@@ -38,7 +48,7 @@ type getFilterSuggestionsResponse = {
 export const getFilterSuggestions = async (type: string, value: string | undefined): Promise<getFilterSuggestionsResponse[]> => {
 	if (!value) return [];
 
-	const response = await fetch(`${API_HOST}/api/${type}/${value}`);
+	const response = await fetch(`${getApiUrl(`/api/${type}/${value}`)}`,{headers:getApiHeaders()});
 	return response.json();
 };
 
@@ -48,6 +58,6 @@ type getDetailsResponse = {
 };
 
 export const getDetails = async (type: string, slug: string): Promise<getDetailsResponse> => {
-	const response = await fetch(`${API_HOST}/api/${type}/details/${slug}`);
+	const response = await fetch(`${getApiUrl(`/api/${type}/details/${slug}`)}`,{headers:getApiHeaders()});
 	return response.json();
 };

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -83,6 +83,11 @@ services:
     volumes:
       - ../client:/app
       - /app/node_modules/
+    environment:
+      - VITE_API_PROTOCOL=http
+      - VITE_API_HOST=${HOST}
+      - VITE_API_PATH=/api/rest
+      - VITE_CACHE_TTL=1000
 
   cabestan-scraper-rcr:
     restart: always


### PR DESCRIPTION
# Amélioration de la configuration CORS et configuration Front

## 🎯 Objectifs
- Permettre les requêtes cross-origin pour le développement local
- Variabiliser la configuration de l'API côté client

## 📝 Modifications principales

### Backend
- Ajout et configuration de `django-cors-headers`
  - Configuration des origines autorisées via `CORS_ALLOWED_ORIGINS`
  - Ajout du middleware CORS
- Modification des filtres de recherche RCR pour supporter les valeurs multiples
- Suppression des sérialiseurs inutilisés (City et Editor)

### Frontend
- Variabilisation des paramètres d'API via variables d'environnement :
  ```typescript
  VITE_API_PROTOCOL=http
  VITE_API_HOST=${HOST}
  VITE_API_PATH=/api/rest
  VITE_CACHE_TTL=1000
  ```
- Ajout des headers d'authentification pour les requêtes API
- Configuration du cache React Query via les variables d'environnement

### CI/CD
- Ajout des variables d'environnement Vite dans le workflow de déploiement staging

