### PR TITLE
feat: Enhance API response structure for search and get endpoints

### DIFF
--- a/app/rest/api.py
+++ b/app/rest/api.py
@@ -224,11 +224,37 @@ def search_editor(request, filters: EditorSearchFilters = Query(...)):
         "id", "title"
     )[:10]
 
-    return list(queryset)
+    response = [
+        {
+            "id": item["id"],
+            "name": item["title"],
+        }
+        for item in queryset
+    ]
+
+    return response
+
+
+@router.get("/publisher/{id}")
+def get_publisher_by_id(request, id: int):
+    publisher = Editor.objects.get(id=id)
+    return {
+        "id": publisher.id,
+        "name": publisher.title,
+    }
 
 
 class CitySearchFilters(Schema):
     str: str
+
+
+@router.get("/city/{id}")
+def get_city_by_id(request, id: int):
+    city = City.objects.get(id=id)
+    return {
+        "id": city.id,
+        "name": city.label,
+    }
 
 
 @router.get("/cities/search")
@@ -240,7 +266,15 @@ def search_city(request, filters: CitySearchFilters = Query(...)):
         "id", "label", "zipcode"
     )[:10]
 
-    return list(queryset)
+    response = [
+        {
+            "id": item["id"],
+            "name": item["label"],
+        }
+        for item in queryset
+    ]
+
+    return response
 
 
 class SuggestionsSearchFilters(Schema):


### PR DESCRIPTION
## ✨ Ajout de points de terminaison d'API pour récupérer les éditeurs et les villes par ID & Amélioration de la recherche

### 📝 Résumé

Cette pull request introduit de nouveaux points de terminaison d'API pour récupérer des informations spécifiques sur les éditeurs et les villes en utilisant leurs ID. De plus, elle améliore la structure de réponse des points de terminaison de recherche pour les éditeurs et les villes, uniformisant le format des données renvoyées. 

### 🛠️ Améliorations & Ajouts

*   ➕ Ajout des points de terminaison `GET /publisher/{id}` et `GET /city/{id}` pour récupérer les informations d'un éditeur ou d'une ville spécifique à partir de son ID.
*   ✨ Amélioration de la structure de réponse des points de terminaison de recherche `GET /cities/search` et  `GET /editor/search` pour renvoyer une liste d'objets avec les clés `id` et `name`.

### ❓ Pourquoi ces changements sont-ils nécessaires ?

*   La récupération d'informations d'éditeurs et de villes par ID est essentielle pour l'affichage des détails spécifiques dans l'interface utilisateur, améliorant ainsi l'expérience utilisateur.
*   L'uniformisation de la structure de réponse des points de terminaison de recherche simplifie le traitement des données côté client et améliore la cohérence de l'API.

### 🔗 Tickets/Issues liés

*   N/A (Aucun ticket spécifique lié dans la description fournie)

### ✅ Tests effectués

*   ✅ Test manuel des nouveaux points de terminaison d'API en utilisant des requêtes HTTP pour vérifier qu'ils renvoient les données correctes pour des ID valides.
*   ✅ Vérification que les points de terminaison de recherche renvoient les données dans le nouveau format attendu.

