### PR TITLE
feat: Add reset filters button with tooltip in search bar

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
 				"@radix-ui/react-popover": "^1.1.6",
 				"@radix-ui/react-select": "^2.1.6",
 				"@radix-ui/react-slot": "^1.1.2",
+				"@radix-ui/react-tooltip": "^1.1.8",
 				"@tailwindcss/vite": "^4.0.8",
 				"@tanstack/react-query": "^5.66.0",
 				"class-variance-authority": "^0.7.1",
@@ -1527,6 +1528,40 @@
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-tooltip": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.8.tgz",
+			"integrity": "sha512-YAA2cu48EkJZdAMHC0dqo9kialOcRStbtiY4nJPaht7Ptrhcvpo+eDChaM6BIs8kL6a8Z5l5poiqLnXcNduOkA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.1",
+				"@radix-ui/react-compose-refs": "1.1.1",
+				"@radix-ui/react-context": "1.1.1",
+				"@radix-ui/react-dismissable-layer": "1.1.5",
+				"@radix-ui/react-id": "1.1.0",
+				"@radix-ui/react-popper": "1.2.2",
+				"@radix-ui/react-portal": "1.1.4",
+				"@radix-ui/react-presence": "1.1.2",
+				"@radix-ui/react-primitive": "2.0.2",
+				"@radix-ui/react-slot": "1.1.2",
+				"@radix-ui/react-use-controllable-state": "1.1.0",
+				"@radix-ui/react-visually-hidden": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
 					"optional": true
 				}
 			}

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
 		"@radix-ui/react-popover": "^1.1.6",
 		"@radix-ui/react-select": "^2.1.6",
 		"@radix-ui/react-slot": "^1.1.2",
+		"@radix-ui/react-tooltip": "^1.1.8",
 		"@tailwindcss/vite": "^4.0.8",
 		"@tanstack/react-query": "^5.66.0",
 		"class-variance-authority": "^0.7.1",

--- a/client/src/components/SearchBar/ResetFiltersButton.tsx
+++ b/client/src/components/SearchBar/ResetFiltersButton.tsx
@@ -1,0 +1,33 @@
+import { X } from "lucide-react";
+import { Button } from "../ui/button";
+import { useNavigate } from "react-router";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useTranslation } from "react-i18next";
+
+export default function ResetFiltersButton() {
+	const navigate = useNavigate();
+	const { t } = useTranslation();
+
+	return (
+		<TooltipProvider>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<Button
+						size="sm"
+						className="bg-foreground text-white cursor-pointer"
+						onClick={() => {
+							navigate({
+								pathname: "/",
+							});
+							navigate(0);
+						}}>
+						<X className="w-4 h-4" />
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent className="text-white">
+					<p>{t("SearchBar.resetFilters")}</p>
+				</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+}

--- a/client/src/components/SearchBar/index.tsx
+++ b/client/src/components/SearchBar/index.tsx
@@ -9,6 +9,7 @@ import DateRangePicker from "./DateRangePicker";
 import { getClientConfig } from "@/api";
 import ComboboxSearchFilter from "./ComboboxSearchFilter";
 import { FilterTypes } from "@/models/Filters";
+import ResetFiltersButton from "./ResetFiltersButton";
 
 export default function SearchBar() {
 	const { t } = useTranslation();
@@ -50,6 +51,7 @@ export default function SearchBar() {
 					{isPublicationDateFilterOpen && <DateRangePicker type={FilterTypes.PUBLICATION_DATES} />}
 					{/* {isTranslationDateFilterOpen && <DateRangePicker type={FilterTypes.TRANSLATION_DATES} />} */}
 					{isReissueDateFilterOpen && <DateRangePicker type={FilterTypes.REISSUE_DATES} />}
+					{searchParams.size > 0 && <ResetFiltersButton />}
 				</div>
 				<div className="">
 					<PopoverMoreFilters

--- a/client/src/components/ui/tooltip.tsx
+++ b/client/src/components/ui/tooltip.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  )
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit rounded-md px-3 py-1.5 text-xs text-balance",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/client/src/i18n/fr.json
+++ b/client/src/i18n/fr.json
@@ -56,7 +56,8 @@
 	},
 	"SearchBar": {
 		"loading": "Chargement des filtres...",
-		"error": "Erreur lors du chargement des filtres: {error.message}"
+		"error": "Erreur lors du chargement des filtres: {error.message}",
+		"resetFilters": "Supprimer tous les filtres"
 	},
 	"filters": {
 		"languages": {


### PR DESCRIPTION
Initiative personnelle, parce que c'était pénible de devoir enlever les filtres un par un et pas intuitif pour les futurs utilisateurs de virer les paramètres de l'URL ^^

- Updated package dependencies to include @radix-ui/react-tooltip
- Created ResetFiltersButton for clearing search filters
- Added translation for reset filters tooltip

![image](https://github.com/user-attachments/assets/51bd5699-3816-4393-8a44-3a17db7bad59)
![image](https://github.com/user-attachments/assets/376c7159-a77f-4d3b-8308-9fe11c6c8869)
