### PR TITLE
fix: Improve RCR search ordering with null handling

### DIFF
--- a/app/rest/api/rcr.py
+++ b/app/rest/api/rcr.py
@@ -2,7 +2,7 @@ from ninja import Router, Query, Schema
 from typing import Optional
 from ..models import Book, Editor, City, Rcr, Author
 from ..views import ClientConfigView
-from django.db.models import Q, Count
+from django.db.models import Q, Count, F
 from datetime import datetime
 import csv
 from django.http import HttpResponse
@@ -160,9 +160,12 @@ def search_rcr(request, filters: RcrSearchFilters = Query(...)):
     # calculate books count
     if shouldCountBook:
         queryset = queryset.annotate(calculated_books_count=Count("books"))
-        queryset = queryset.order_by("-calculated_books_count", "title")
+        queryset = queryset.order_by(
+            F("calculated_books_count").desc(nulls_last=True), "title"
+        )
+
     else:
-        queryset = queryset.order_by("-books_count", "title")
+        queryset = queryset.order_by(F("books_count").desc(nulls_last=True), "title")
 
     if not filters.map_format:
         total = queryset.count()


### PR DESCRIPTION
## ✨ Améliorations Principales

*   **✅ Optimisation de la requête RCR :**
    *   Correction du tri des résultats de la recherche RCR. Le tri par nombre de livres est maintenant géré correctement, affichant en priorité les RCR avec le plus de livres (avec gestion des valeurs nulles).
    *   Utilisation de `F("calculated_books_count").desc(nulls_last=True)` et `F("books_count").desc(nulls_last=True)` pour un tri plus précis et robuste, assurant que les valeurs nulles sont placées en dernier.

## 🐛 Corrections de Bugs
*   Correction du tri des RCR : Le tri par `books_count` et `calculated_books_count` ne fonctionnait pas comme prévu, en particulier en présence de valeurs nulles. La nouvelle implémentation corrige ce problème.
