### PR TITLE
fix: Improve navigation history handling with replace option

### DIFF
--- a/client/src/components/SearchBar/ResetFiltersButton.tsx
+++ b/client/src/components/SearchBar/ResetFiltersButton.tsx
@@ -17,9 +17,12 @@ export default function ResetFiltersButton() {
 						size="sm"
 						className="bg-foreground text-white cursor-pointer"
 						onClick={() => {
-							navigate({
-								pathname: location.pathname,
-							});
+							navigate(
+								{
+									pathname: location.pathname,
+								},
+								{ replace: true }
+							);
 							navigate(0);
 						}}>
 						<X className="w-4 h-4" />

--- a/client/src/hooks/useSetFilterSearchParams.ts
+++ b/client/src/hooks/useSetFilterSearchParams.ts
@@ -21,10 +21,13 @@ export function useSetFilterSearchParams() {
 			searchParams.set("page", "1");
 		}
 
-		navigate({
-			pathname: location.pathname,
-			search: searchParams.toString(),
-		});
+		navigate(
+			{
+				pathname: location.pathname,
+				search: searchParams.toString(),
+			},
+			{ replace: true }
+		);
 	}
 
 	return setFilterSearchParams;


### PR DESCRIPTION
Permet de naviguer dans l'historique entre la page d'accueil et les pages de détail de RCR sans interactions avec les filtres