### PR TITLE
feat: Add allBooks filter to book search and adjust pagination logic

### DIFF
--- a/app/rest/api/book.py
+++ b/app/rest/api/book.py
@@ -36,6 +36,7 @@ class BookSearchFilters(Schema):
     subtitle: Optional[str] = None
     string: Optional[str] = None
     nullValues: Optional[bool] = True
+    allBooks: Optional[bool] = False
 
 
 @router.get("/rcr/{rcr_number}/books/search")
@@ -129,10 +130,13 @@ def get_rcr_books(request, rcr_number: str, filters: BookSearchFilters = Query(.
     queryset = Book.objects.filter(conditions)
 
     # Pagination
-    total = queryset.count()
-    start = (filters.page - 1) * filters.itemsPerPage
-    end = start + filters.itemsPerPage
-    queryset = queryset[start:end]
+    if not filters.allBooks:
+        total = queryset.count()
+        start = (filters.page - 1) * filters.itemsPerPage
+        end = start + filters.itemsPerPage
+        queryset = queryset[start:end]
+    else:
+        total = 0
 
     response = {
         "pagination": {
@@ -148,6 +152,7 @@ def get_rcr_books(request, rcr_number: str, filters: BookSearchFilters = Query(.
 
 @router.get("/rcr/{rcr_number}/books/export", auth=None)
 def export_rcr_books(request, rcr_number: str, filters: BookSearchFilters = Query(...)):
+    filters.allBooks = True
     data = get_rcr_books(request, rcr_number=rcr_number, filters=filters)
 
     response = HttpResponse(


### PR DESCRIPTION
- Introduced an optional allBooks filter in BookSearchFilters to control pagination behavior.
- Updated get_rcr_books function to handle cases where allBooks is true, bypassing pagination and setting total to 0.
- Ensured allBooks is set to true when exporting RCR books.